### PR TITLE
Fixed the 'first card blank' bug

### DIFF
--- a/classes/class-s4wc_api.php
+++ b/classes/class-s4wc_api.php
@@ -238,12 +238,11 @@ class S4WC_API {
             if( isset($element->$name) ) {
                 if( $element->$name == $needle ) {
                     return $index;
-                } else {
-                    return -1;
-                }
+                } 
             } else {
                 return -1;
             }
         }
+        return -1;
     } 
 }


### PR DESCRIPTION
As many people have been talking about on the Wordpress support forum for this plugin, the first card registered when a customer is created is blank. This happens because the format of the response object from Stripe has changed in the latest versions. To fix I simply edited the format expected by the plugin. 

NOTE: This may make the plugin incompatible with older versions of the API.