### PR TITLE
Fixed an issue when using a saved card at checkout

### DIFF
--- a/classes/class-s4wc_gateway.php
+++ b/classes/class-s4wc_gateway.php
@@ -794,8 +794,10 @@ class S4WC_Gateway extends WC_Payment_Gateway {
         $stripe_charge_data['capture']  = ( $this->settings['charge_type'] == 'capture' ) ? 'true' : 'false';
         $stripe_charge_data['expand[]'] = 'balance_transaction';
 
+        $new_card = FALSE;
+        if($this->form_data['chosen_card'] === 'new') { $new_card = TRUE;}
         // Make sure we only create customers if a user is logged in
-        if ( is_user_logged_in() && $this->settings['saved_cards'] === 'yes' && $this->form_data['chosen_card'] ) {
+        if (is_user_logged_in() && $this->settings['saved_cards'] === 'yes' && (($this->form_data['chosen_card'] === 'new' && $this->form_data['save_card'] === TRUE) || $this->form_data['chosen_card'] !== 'new')) {
 
             // Add a customer or retrieve an existing one
             $customer = $this->get_customer();

--- a/classes/class-s4wc_gateway.php
+++ b/classes/class-s4wc_gateway.php
@@ -795,7 +795,7 @@ class S4WC_Gateway extends WC_Payment_Gateway {
         $stripe_charge_data['expand[]'] = 'balance_transaction';
 
         // Make sure we only create customers if a user is logged in
-        if ( is_user_logged_in() && $this->settings['saved_cards'] === 'yes' && $this->form_data['save_card'] ) {
+        if ( is_user_logged_in() && $this->settings['saved_cards'] === 'yes' && $this->form_data['chosen_card'] ) {
 
             // Add a customer or retrieve an existing one
             $customer = $this->get_customer();

--- a/classes/class-s4wc_gateway.php
+++ b/classes/class-s4wc_gateway.php
@@ -794,10 +794,8 @@ class S4WC_Gateway extends WC_Payment_Gateway {
         $stripe_charge_data['capture']  = ( $this->settings['charge_type'] == 'capture' ) ? 'true' : 'false';
         $stripe_charge_data['expand[]'] = 'balance_transaction';
 
-        $new_card = FALSE;
-        if($this->form_data['chosen_card'] === 'new') { $new_card = TRUE;}
         // Make sure we only create customers if a user is logged in
-        if (is_user_logged_in() && $this->settings['saved_cards'] === 'yes' && (($new_card === TRUE && $this->form_data['save_card'] === TRUE) || $this->form_data['chosen_card'] !== 'new')) {
+        if (is_user_logged_in() && $this->settings['saved_cards'] === 'yes' && (($this->form_data['chosen_card'] === 'new' && $this->form_data['save_card'] === TRUE) || $this->form_data['chosen_card'] !== 'new')) {
 
             // Add a customer or retrieve an existing one
             $customer = $this->get_customer();

--- a/classes/class-s4wc_gateway.php
+++ b/classes/class-s4wc_gateway.php
@@ -797,7 +797,7 @@ class S4WC_Gateway extends WC_Payment_Gateway {
         $new_card = FALSE;
         if($this->form_data['chosen_card'] === 'new') { $new_card = TRUE;}
         // Make sure we only create customers if a user is logged in
-        if (is_user_logged_in() && $this->settings['saved_cards'] === 'yes' && (($this->form_data['chosen_card'] === 'new' && $this->form_data['save_card'] === TRUE) || $this->form_data['chosen_card'] !== 'new')) {
+        if (is_user_logged_in() && $this->settings['saved_cards'] === 'yes' && (($new_card === TRUE && $this->form_data['save_card'] === TRUE) || $this->form_data['chosen_card'] !== 'new')) {
 
             // Add a customer or retrieve an existing one
             $customer = $this->get_customer();


### PR DESCRIPTION
There was an issue connecting to the Stripe gateway when using a saved card. After a bit of probing I found out it was because the card field been sent was blank. I solved this by changing the field that is been checked to `chosen_card` instead of `save_card`. It all seems to be working as expected now charges go through for new card (not saved), new cards (saved), and saved cards.