### PR TITLE
Removed unnecessary check to show stripe errors

### DIFF
--- a/classes/class-s4wc_api.php
+++ b/classes/class-s4wc_api.php
@@ -204,10 +204,6 @@ class S4WC_API {
      * @return      array
      */
     public static function parse_response( $response ) {
-        if ( is_wp_error( $response ) ) {
-            throw new Exception( 's4wc_problem_connecting' );
-        }
-
         if ( empty( $response['body'] ) ) {
             throw new Exception( 's4wc_empty_response' );
         }


### PR DESCRIPTION
I didn't find a use case when this check should be triggered. On opposite, this check doesn't allow the plugin to show error texts from stripe. 

Check error codes with cards from here: https://stripe.com/docs/testing
