### PR TITLE
Fix: is_available method bug

### DIFF
--- a/classes/class-s4wc_gateway.php
+++ b/classes/class-s4wc_gateway.php
@@ -100,7 +100,7 @@ class S4WC_Gateway extends WC_Payment_Gateway {
         }
 
         // Stripe will only process orders of at least 50 cents otherwise
-        elseif ( $this->get_order_total() * 100 < 50 ) {
+        elseif ( WC()->cart && $this->get_order_total() > 0 && $this->get_order_total() * 100 < 50 ) {
             return false;
         }
 


### PR DESCRIPTION
Hi Stephen. Found that bug today.

->is_available() method was returning false every time, when called outside
of native checkout process. For example, if we call $woocommerce->payment_gateways->get_available_payment_gateways(); externally, in some other plugin or function.

Thanks for awesome plugin!
